### PR TITLE
Fix metadata uniformization

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "^4.0.1",
     "mocha-webpack": "^1.0.1",
     "ts-loader": "^3.1.1",
-    "typescript": "^2.6.1",
+    "typescript": "^3.0.1",
     "webpack": "^3.8.1"
   },
   "dependencies": {

--- a/src/helpers/paramtypes.ts
+++ b/src/helpers/paramtypes.ts
@@ -2,6 +2,5 @@ import { Metadata } from '../metadata';
 
 export function getParamtypes(target: any): { token: any }[] {
 	return (Metadata
-		.get(target, 'design:paramtypes') || [])
-		.map(paramtype => ({ token: paramtype }));
+		.get(target, 'design:paramtypes') || []);
 }

--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -11,7 +11,7 @@ export function Inject(token: any) {
 	return (target: any, key: string, index: number) => {
 		let metadata = Metadata.get(target) || { provide: [] };
 
-		metadata.provide[index] = { ...metadata.provide[index], token };
+		metadata.provide[index] = token;
 
 		Metadata.set(target, metadata);
 	};

--- a/src/injector/injector.spec.ts
+++ b/src/injector/injector.spec.ts
@@ -63,7 +63,7 @@ describe('Injector', () => {
 
 		injector.register(ProviderConfig, {
 			factory: () => config,
-			provide: []
+			provide: [],
 		});
 
 		expect(injector.resolve<Provider>(Provider).injectedConfig).to.not.be.undefined;

--- a/src/injector/injector.spec.ts
+++ b/src/injector/injector.spec.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 
 import { Injector } from './injector';
 import { Injectable } from '../injectable';
-import { Metadata } from '../metadata';
 import { Inject } from '../inject';
 
 describe('Injector', () => {

--- a/src/injector/injector.ts
+++ b/src/injector/injector.ts
@@ -11,10 +11,6 @@ export interface ProvideMetadata<TProvider> {
 	singleton?: boolean;
 }
 
-export interface ResolveRequest {
-	token: any;
-	provide: ResolveRequest[]; 
-}
 
 /**
  * Supplied options, if any, are merged into defaults.
@@ -124,7 +120,7 @@ export class Injector {
 		return this._resolve(factory, provide);
 	}
 
-	private _resolve<T>(factory: (...args: any[]) => T, provide: ResolveRequest[]): T {
-		return factory(...provide.map(({ token }) => this.resolve(token)));
+	private _resolve<T>(factory: (...args: any[]) => T, provide: any[]): T {
+		return factory(...provide.map(provider => this.resolve(provider)));
 	}
 }

--- a/src/injector/injector.ts
+++ b/src/injector/injector.ts
@@ -2,7 +2,6 @@ import { Metadata } from '../metadata';
 import { Newable } from '../newable';
 
 import { isClass } from '../helpers/isClass';
-import { isArrayEmpty } from '../helpers/isArrayEmpty';
 
 import { merge } from '../helpers/merge';
 

--- a/src/injector/injector.ts
+++ b/src/injector/injector.ts
@@ -132,7 +132,7 @@ export class Injector {
 	 * 
 	 * @param options Optional provider resolution options.
 	 * 
-	 * __Note__: Factory function (and optionally provide) be supplied unless token is a class.
+	 * __Note__: Factory function (and optionally provide) should be supplied unless token is a class.
 	 * Otherwise it will throw upon registraction, or, if token is a function, upon
 	 * instantiation.
 	 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3090,9 +3090,9 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typescript@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-js@^2.8.29:
   version "2.8.29"


### PR DESCRIPTION
### Purpose:
This PR aims to improve dodgy `_uniformProvideMetadata` logic as well as removes obsolete internal  `ResolveRequest` interface.