### PR TITLE
v0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "inwerter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Modular dependency injection simplified",
   "main": "dist/index.umd.js",
-  "types": "dist/esm/index.d.ts",
-  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "tsc --declaration --outDir dist && rollup -c",


### PR DESCRIPTION
This fixes module structure.

`package.json` pointed to files in non-existent directory `dist/esm` in `types` and `module` fields, which would not load types and ES2015 code.

To prevent this, tests of output module structure will be implemented in https://github.com/dulowski-marek/inwerter/issues/38